### PR TITLE
Add settings-file-path configuration for FHIR settings

### DIFF
--- a/docker/application.yaml
+++ b/docker/application.yaml
@@ -37,6 +37,7 @@ validator:
     - 'hl7.fhir.r4.examples#4.0.1'
   tx-server: # 'https://tx.fhir.org/r4'
   tx-log:
+  settings-file-path:
   locale: en
   remove-text: true
   any-extensions-allowed: false

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -122,6 +122,26 @@ The application.yaml file contains several main sections for configuring differe
 - **Required**: No
 - **Description**: The terminology server log file to use for validation. This is an optional field.
 
+### validator.settings-file-path
+- **Type**: String
+- **Required**: No
+- **Description**: The path to the settings file for FHIR settings. This is an optional field. The settings file allows you to configure custom package servers, authentication, and other FHIR-specific settings.
+- **Example**: '/path/to/fhir-settings.json'
+- **Reference**: For detailed information about fhir-settings.json format and options, see: https://confluence.hl7.org/spaces/FHIR/pages/161072808/Using+fhir-settings.json
+- **Sample fhir-settings.json**:
+  ```json
+  {
+    "ignoreDefaultPackageServers": true,
+    "servers": [
+      {
+        "url": "http://mypackageserver:4873",
+        "type": "fhir-package",
+        "authenticationType" : "none"
+      }
+    ]
+  }
+  ```
+
 ### validator.locale
 - **Type**: String
 - **Default**: en
@@ -217,6 +237,7 @@ validator:
     - 'hl7.fhir.us.core#6.1.0'
     - 'il.core.fhir.r4#0.17.5'
   tx-server: 'https://tx.fhir.org/r4'
+  settings-file-path: '/config/fhir-settings.json'
 ```
 
 ### Development Configuration
@@ -231,6 +252,34 @@ validator:
   verbose: true
   show-times: true
   level: warnings
+```
+
+### Configuration with Custom Package Server
+```yaml
+server:
+  port: 8080
+
+validator:
+  sv: '4.0.1'
+  ig:
+    - 'hl7.fhir.us.core#6.1.0'
+    - 'custom.implementation.guide#1.0.0'
+  settings-file-path: '/config/fhir-settings.json'
+  tx-server: 'https://tx.fhir.org/r4'
+```
+
+Example `fhir-settings.json` for the above configuration:
+```json
+{
+  "ignoreDefaultPackageServers": true,
+  "servers": [
+    {
+      "url": "http://mypackageserver:4873",
+      "type": "fhir-package",
+      "authenticationType" : "none"
+    }
+  ]
+}
 ```
 
 ## Command Line Override

--- a/src/main/java/il/co/outburn/rest/ApplicationProperties.java
+++ b/src/main/java/il/co/outburn/rest/ApplicationProperties.java
@@ -3,6 +3,8 @@ package il.co.outburn.rest;
 import java.io.IOException;
 import java.util.List;
 
+import org.hl7.fhir.utilities.npm.PackageServer;
+
 public class ApplicationProperties {
     public static String getAppVersion() {
         Package pkg = ApplicationProperties.class.getPackage();
@@ -21,6 +23,7 @@ public class ApplicationProperties {
         public List<String> implementationGuides;
         public List<String> loadedPackages;
         public String terminologyServer;
+        public List<String> packageServers;
 
         public ApplicationInfo(FhirValidatorConfiguration configuration) throws IOException {
             var validationEngine = FhirValidationEngineCache.getValidationEngine();
@@ -31,6 +34,11 @@ public class ApplicationProperties {
             implementationGuides = configuration.ig;
             loadedPackages = validationEngine.getContext().getLoadedPackages();
             terminologyServer = configuration.getTxServer();
+            packageServers = validationEngine.getPcm()
+                    .getPackageServers()
+                    .stream()
+                    .map(PackageServer::getUrl)
+                    .toList();
         }
     }
 }

--- a/src/main/java/il/co/outburn/rest/FhirValidatorApplication.java
+++ b/src/main/java/il/co/outburn/rest/FhirValidatorApplication.java
@@ -78,7 +78,7 @@ public class FhirValidatorApplication {
         }
     }
 
-    private void configureFhirSettings() throws FileNotFoundException  {
+    private void configureFhirSettings() throws FileNotFoundException {
         var settingsFilePath = configuration.getSettingsFilePath();
         if (settingsFilePath == null) return;
 
@@ -88,9 +88,9 @@ public class FhirValidatorApplication {
             throw new FileNotFoundException("FHIR settings file does not exist: " + settingsFilePath);
         }
 
-        settingsFilePath = path.toAbsolutePath().toString();
-        log.info("FHIR settings file path: {}", settingsFilePath);
-        FhirSettings.setExplicitFilePath(settingsFilePath);
+        var settingsFileAbsolutePath = path.toAbsolutePath().toString();
+        log.info("FHIR settings file path: {}", settingsFileAbsolutePath);
+        FhirSettings.setExplicitFilePath(settingsFileAbsolutePath);
         
         // Log configured servers for debugging
         var servers = FhirSettings.getServers();

--- a/src/main/java/il/co/outburn/rest/FhirValidatorConfiguration.java
+++ b/src/main/java/il/co/outburn/rest/FhirValidatorConfiguration.java
@@ -64,6 +64,17 @@ public class FhirValidatorConfiguration {
     }
 
     /**
+     * The path to the settings file for FHIR settings. This is an optional field.
+     */
+    @Setter
+    String settingsFilePath;
+    public String getSettingsFilePath() {
+        if (settingsFilePath == null || settingsFilePath.isBlank() || settingsFilePath.isEmpty())
+            return null;
+        return settingsFilePath;
+    }
+
+    /**
      * Removes OperationOutcome text from the validation result. This is an optional field.
      */
     @Getter
@@ -173,6 +184,7 @@ public class FhirValidatorConfiguration {
             "Implementation Guides: " + ig,
             "Terminology Server URL: " + getTxServer(),
             "Terminology Server Log: " + getTxLog(),
+            "Settings File Path: " + getSettingsFilePath(),
             "Remove OperationOutcome Text: " + removeText,
             "Allow Any Extensions: " + anyExtensionsAllowed,
             "Allowed Extension Domains: " + extensionDomains,

--- a/src/main/java/il/co/outburn/rest/FhirValidatorConfiguration.java
+++ b/src/main/java/il/co/outburn/rest/FhirValidatorConfiguration.java
@@ -20,7 +20,7 @@ public class FhirValidatorConfiguration {
     @Setter
     String sv;
     public String getSv() {
-        if (sv == null || sv.isBlank() || sv.isEmpty())
+        if (sv == null || sv.isBlank())
             return "4.0.1";
         return sv;
     }
@@ -47,7 +47,7 @@ public class FhirValidatorConfiguration {
     @Setter
     String txServer;
     public String getTxServer() {
-        if (txServer == null || txServer.isBlank() || txServer.isEmpty())
+        if (txServer == null || txServer.isBlank())
             return null;
         return txServer;
     }
@@ -58,7 +58,7 @@ public class FhirValidatorConfiguration {
     @Setter
     String txLog;
     public String getTxLog() {
-        if (txLog == null || txLog.isBlank() || txLog.isEmpty())
+        if (txLog == null || txLog.isBlank())
             return null;
         return txLog;
     }
@@ -69,7 +69,7 @@ public class FhirValidatorConfiguration {
     @Setter
     String settingsFilePath;
     public String getSettingsFilePath() {
-        if (settingsFilePath == null || settingsFilePath.isBlank() || settingsFilePath.isEmpty())
+        if (settingsFilePath == null || settingsFilePath.isBlank())
             return null;
         return settingsFilePath;
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -37,6 +37,7 @@ validator:
     - 'hl7.fhir.r4.examples#4.0.1'
   tx-server: # 'https://tx.fhir.org/r4'
   tx-log:
+  settings-file-path:
   locale: en
   remove-text: true
   any-extensions-allowed: false

--- a/windows/application.yaml
+++ b/windows/application.yaml
@@ -44,6 +44,7 @@ validator:
     - 'il.core.fhir.r4#0.17.5'
   tx-server: # 'https://tx.fhir.org/r4'
   tx-log:
+  settings-file-path:
   locale: en
   remove-text: true
   any-extensions-allowed: false


### PR DESCRIPTION
This PR adds support for configuring FHIR settings through a settings-file-path property.

## Changes Made

- ✅ Added `settings-file-path` property to all application.yaml files
- ✅ Updated `FhirValidatorConfiguration` with `settingsFilePath` property  
- ✅ Implemented FHIR settings file loading in `FhirValidatorApplication`
- ✅ Added comprehensive documentation with examples and HL7 reference
- ✅ Include package server information in application properties
- ✅ Added sample fhir-settings.json configuration example

## Configuration Example

```yaml
validator:
  sv: '4.0.1'
  settings-file-path: '/config/fhir-settings.json'
```

Sample fhir-settings.json:
```json
{
  "ignoreDefaultPackageServers": true,
  "servers": [
    {
      "url": "http://mypackageserver:4873",
      "type": "fhir-package",
      "authenticationType" : "none"
    }
  ]
}
```

## Documentation

Updated documentation includes reference to HL7 Confluence page: https://confluence.hl7.org/spaces/FHIR/pages/161072808/Using+fhir-settings.json

Closes #16